### PR TITLE
check if executed query is valid

### DIFF
--- a/.changeset/perfect-masks-design.md
+++ b/.changeset/perfect-masks-design.md
@@ -1,0 +1,5 @@
+---
+'@graphql-ez/plugin-automatic-persisted-queries': patch
+---
+
+fix "store query if valid"

--- a/packages/plugin/automatic-persisted-queries/src/plugin.ts
+++ b/packages/plugin/automatic-persisted-queries/src/plugin.ts
@@ -7,7 +7,7 @@ import {
   PersistedQueryNotFoundError,
   PersistedQueryNotSupportedError,
 } from './errors';
-import { GraphQLError } from 'graphql';
+import { GraphQLError, ExecutionResult } from 'graphql';
 import { isDocumentNode } from '@graphql-tools/utils';
 
 export interface PersistedQuery {
@@ -170,13 +170,10 @@ export const ezAutomaticPersistedQueries = (options?: AutomaticPersistedQueryOpt
 
         // override execute so we can store query if it's valid
         options.execute = async (...args: any[]) => {
-          const result = await execute(...args);
-          try {
-            await store.set(hash, query);
-          } catch (e) {
-            // todo: throw not supported error
-            throw e;
-          }
+          const result: ExecutionResult = await execute(...args);
+
+          if (!result.errors?.length) Promise.resolve(store.set(hash, query)).catch(console.error);
+
           return result;
         };
       }

--- a/packages/plugin/automatic-persisted-queries/src/plugin.ts
+++ b/packages/plugin/automatic-persisted-queries/src/plugin.ts
@@ -172,7 +172,13 @@ export const ezAutomaticPersistedQueries = (options?: AutomaticPersistedQueryOpt
         options.execute = async (...args: any[]) => {
           const result: ExecutionResult = await execute(...args);
 
-          if (!result.errors?.length) Promise.resolve(store.set(hash, query)).catch(console.error);
+          if (!result.errors?.length) {
+            try {
+              Promise.resolve(store.set(hash, query)).catch(console.error);
+            } catch (err) {
+              console.error(err);
+            }
+          }
 
           return result;
         };

--- a/packages/plugin/automatic-persisted-queries/src/plugin.ts
+++ b/packages/plugin/automatic-persisted-queries/src/plugin.ts
@@ -202,7 +202,11 @@ export const ezAutomaticPersistedQueries = (options?: AutomaticPersistedQueryOpt
       plugins.push({
         onSchemaChange() {
           // unfortunately onSchemaChange is not async
-          Promise.resolve(store.clear()).catch(console.error);
+          try {
+            Promise.resolve(store.clear()).catch(console.error);
+          } catch (err) {
+            console.error(err);
+          }
         },
       });
     },


### PR DESCRIPTION
@ccollie `execute` never throws, shouldn't be the process of checking if the query should be saved not having any error in the execution?

and also, there isn't any specific reason of waiting for the "set" to be done